### PR TITLE
OCP 4.6 updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,31 @@
 # openshift-falcon-daemonset
 Sample OpenShift DaemonSet to deploy CrowdStrike Falcon within Red Hat OpenShift or OpenShift Origin clusters.
 
-# Repository Structyre
+# Repository Structure
 | File / Folder | Description |
 |:--------------|:------------|
-| config-map.yaml | |
-| crwd-falcon-agent.yaml | OpenShift DaemonSet Deployment Specification for Falcon Agent |
+| config-map.yaml | OpenShift Config Map, containers options passed to Falcon sensor (such as CID). |
+| crwd-falcon-agent.yaml | OpenShift DaemonSet Deployment Specification for Falcon Agent. |
 
-## Requirements
-* Running OpenShift 4.x Cluster
-* ``oc`` CLI installed
-* Your CrowdStrike Customer ID (CrowdStrike ``CID``)
+# Requirements
+* Falcon Linux Sensor that supports the kernel on the worker nodes. For RHEL 8.3 systems, as of November 2020, this will require pre-release access to the Falcon sensor. Contact your CrowdStrike account team for access.
+* Functioning OpenShift Cluster. This daemonset has been tested on:
+  * OpenShift 4.4.29
+  * OpenShift 4.5.17
+  * OpenShift 4.6.1
+* ``oc`` CLI installed.
+* Sufficient permissions on your OpenShift cluster to import/create containers (e.g. Image Streams), create ConfigMaps, and create DaemonSets.
+* Your CrowdStrike Customer ID (CrowdStrike ``CID``).
 * Container image of the Falcon sensor. See https://github.com/CrowdStrike/dockerfiles for inspiration on creating your Docker images.
 
 
-## Deployment Guide
+# Deployment Guide
 
-### Required Parameters
+## Required Parameters
 * In ``config-map.yaml``, place your CrowdStrike Customer ID (CID) in the ``FALCONCTL_OPT_CID`` field.
 * In ``crwd-falcon-agent.yaml``, place the URL to your container image in the ``containers`` -> ``name`` -> ``image`` stanza.
 
-### Deploy the DaemonSet
+## Deploy the DaemonSet
 
 * Login to your OpenShift Cluster
   * ``oc login --token=<<token>> --server=https://api.YourOpenShiftCluster.com:6443``
@@ -55,6 +60,35 @@ Sample OpenShift DaemonSet to deploy CrowdStrike Falcon within Red Hat OpenShift
 `````
 * Deploy the Falcon DaemonSet
   * ``$ oc create -f crwd-falcon-agent.yaml``
+
+# Troubleshooting
+Retrieve the names of the pods relating to your Falcon sensor deployment:
+
+```shell
+$ oc get pods
+
+NAME                  READY   STATUS             RESTARTS   AGE
+falcon-sensor-82lzw   0/2     CrashLoopBackOff   5          6m8s
+falcon-sensor-f4jrr   0/2     Error              6          6m8s
+falcon-sensor-rln6k   0/2     CrashLoopBackOff   5          6m8s
+```
+
+Look at the previous pod logs of an instance of the sensor container:
+```shell
+$ oc logs falcon-sensor-f4jrr -c sensor-container -p
+```
+
+If no logs appear, or if you receive an error about ``previous terminated container "sensor-container" in pod "falcon-sensor-f4jrr" not found``, debug the pod. The following command should create a copy of the pod and provide a shell:
+```shell
+$ oc debug pod/falcon-sensor-f4jrr
+```
+
+Common issues:
+1. DaemonSet deploys, pods are running, but no detections are generated!
+``oc debug`` into the pod (or access terminal via OpenShift Console) to verify your sensor is not in Reduced
+Functionality Mode (RFM). This is often caused by the variance between CoreOS and RHEL kernels, where CoreOS often
+releases different kernel versions than those present in RHEL. File a bug with CrowdStrike requesting a new
+kernel version to be supported.
 
 # Many Thanks
 Thank you to [Dinesh Subhraveti](https://www.linkedin.com/in/subhraveti/) whose initial code inspired this repo!

--- a/config-map.yaml
+++ b/config-map.yaml
@@ -7,7 +7,7 @@ metadata:
   name: falconctl-options
   namespace: default
 data:
-  FALCONCTL_OPT_CID: ""
+  FALCONCTL_OPT_CID: "YOURCID"
   # FALCONCTL_OPT_AID: 
   # FALCONCTL_OPT_APD:
   # FALCONCTL_OPT_APH:

--- a/config-map.yaml
+++ b/config-map.yaml
@@ -7,7 +7,7 @@ metadata:
   name: falconctl-options
   namespace: default
 data:
-  FALCONCTL_OPT_CID: "YOURCID"
+  FALCONCTL_OPT_CID: ""
   # FALCONCTL_OPT_AID: 
   # FALCONCTL_OPT_APD:
   # FALCONCTL_OPT_APH:

--- a/crwd-falcon-agent.yaml
+++ b/crwd-falcon-agent.yaml
@@ -32,9 +32,9 @@ spec:
         
         #
         # For example, with Red Hat OpenShift's internal registry:
-        # image: image-registry.openshift-image-registry.svc:5000/default/falcon-sensor
+        # image: image-registry.openshift-image-registry.svc:5000/default/falcon-sensor:latest
         #
-        image: path.to.svc/yourimage
+        image: image-registry.openshift-image-registry.svc:5000/default/falcon-sensor:latest
         volumeMounts:
         - name: dev
           mountPath: /dev
@@ -57,7 +57,7 @@ spec:
       # are routed through k8s log driver.
       - name: log
         image: busybox
-        args: [/bin/sh, -c, 'tail -n1 -f /var/log/falcon-sensor.log']
+        args: [/bin/sh, -c, 'tail --retry -n1 -f /var/log/falcon-sensor.log']
         volumeMounts:
         - name: var-log
           mountPath: /var/log


### PR DESCRIPTION
- Enumerates tested versions
- README cleanup
- Set default container image path to the openshift registry